### PR TITLE
[demo] export DemoActivity

### DIFF
--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:supportsRtl="true"
         android:theme="@android:style/Theme.DeviceDefault"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name=".DemoActivity">
+        <activity android:name=".DemoActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
```
Manifest merger failed : android:exported needs to be explicitly specified for <activity>. 
Apps targeting Android 12 and higher are required to specify an explicit value for 
`android:exported` when the corresponding component has an intent filter defined. 
See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
```