### PR TITLE
Fix Apk installer fails when SDK >= 31

### DIFF
--- a/demo/src/main/java/rikka/shizuku/demo/DemoActivity.java
+++ b/demo/src/main/java/rikka/shizuku/demo/DemoActivity.java
@@ -14,6 +14,7 @@ import android.content.pm.IPackageInstaller;
 import android.content.pm.IPackageInstallerSession;
 import android.content.pm.PackageInstaller;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.Process;
@@ -215,6 +216,7 @@ public class DemoActivity extends Activity {
         ContentResolver cr = getContentResolver();
         StringBuilder res = new StringBuilder();
         String installerPackageName;
+        String installerAttributionTag = null;
         int userId;
         boolean isRoot;
 
@@ -224,9 +226,11 @@ public class DemoActivity extends Activity {
 
             // the reason for use "com.android.shell" as installer package under adb is that getMySessions will check installer package's owner
             installerPackageName = isRoot ? getPackageName() : "com.android.shell";
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                installerAttributionTag = getAttributionTag();
+            }
             userId = isRoot ? Process.myUserHandle().hashCode() : 0;
-            packageInstaller = PackageInstallerUtils.createPackageInstaller(_packageInstaller, installerPackageName, userId);
-
+            packageInstaller = PackageInstallerUtils.createPackageInstaller(_packageInstaller, installerPackageName, installerAttributionTag, userId);
             int sessionId;
             res.append("createSession: ");
 

--- a/demo/src/main/java/rikka/shizuku/demo/util/PackageInstallerUtils.java
+++ b/demo/src/main/java/rikka/shizuku/demo/util/PackageInstallerUtils.java
@@ -12,8 +12,11 @@ import java.lang.reflect.InvocationTargetException;
 @SuppressWarnings({"JavaReflectionMemberAccess"})
 public class PackageInstallerUtils {
 
-    public static PackageInstaller createPackageInstaller(IPackageInstaller installer, String installerPackageName, int userId) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        if (Build.VERSION.SDK_INT >= 26) {
+    public static PackageInstaller createPackageInstaller(IPackageInstaller installer, String installerPackageName, String installerAttributionTag, int userId) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return PackageInstaller.class.getConstructor(IPackageInstaller.class, String.class, String.class, int.class)
+                    .newInstance(installer, installerPackageName, installerAttributionTag, userId);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             return PackageInstaller.class.getConstructor(IPackageInstaller.class, String.class, int.class)
                     .newInstance(installer, installerPackageName, userId);
         } else {


### PR DESCRIPTION
The Constructor of PackageManager has changed when SDK >=31(Android 12+)

[Android 11](https://cs.android.com/android/platform/superproject/+/android-11.0.0_r9:frameworks/base/core/java/android/content/pm/PackageInstaller.java;bpv=1;bpt=1;l=413?gsn=PackageInstaller&gs=kythe%3A%2F%2Fandroid.googlesource.com%2Fplatform%2Fsuperproject%3Flang%3Djava%3Fpath%3Dandroid.content.pm.PackageInstaller%237719fbee21980f008741bc790f6fe64a9047a7118747f15bdd7fe6cb62da4d6c)

[Android 12+](https://cs.android.com/android/platform/superproject/+/android-12.0.0_r1:frameworks/base/core/java/android/content/pm/PackageInstaller.java;bpv=1;bpt=1;l=417?gsn=PackageInstaller&gs=kythe%3A%2F%2Fandroid.googlesource.com%2Fplatform%2Fsuperproject%3Flang%3Djava%3Fpath%3Dandroid.content.pm.PackageInstaller%237719fbee21980f008741bc790f6fe64a9047a7118747f15bdd7fe6cb62da4d6c)