### PR TITLE
Set target classloader as thread classloader

### DIFF
--- a/server-shared/src/main/java/rikka/shizuku/server/UserService.java
+++ b/server-shared/src/main/java/rikka/shizuku/server/UserService.java
@@ -65,6 +65,7 @@ public class UserService {
                             : new UserHandleHidden(userId));
             Context context = Refine.<ContextHidden>unsafeCast(systemContext).createPackageContextAsUser(pkg, Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY, userHandle);
             ClassLoader classLoader = context.getClassLoader();
+            Thread.currentThread().setContextClassLoader(classLoader);
             Class<?> serviceClass = classLoader.loadClass(cls);
             Constructor<?> constructorWithContext = null;
             try {


### PR DESCRIPTION
This is needed when the JNI itself attempts to resolve Java classes in the target Service, aka using JNIEnv.FindClass.

Namely, this helps with DotNet MAUI apps not loading in the Shizuku context and crashing with `GetClassGRef: class net/dot/android/crypto/DotnetProxyTrustManager was not found` in logcat.