### PR TITLE
Fix typo in build messages for Release and Debug

### DIFF
--- a/rish/src/main/cpp/CMakeLists.txt
+++ b/rish/src/main/cpp/CMakeLists.txt
@@ -7,12 +7,12 @@ set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Werror=format -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -fno-threadsafe-statics)
 
 if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message("Builing Release...")
+    message("Building Release...")
 
     add_compile_options(-Os -flto -fvisibility=hidden -fvisibility-inlines-hidden)
     add_link_options(-flto -Wl,--exclude-libs,ALL -Wl,--gc-sections -Wl,--strip-all)
 else ()
-    message("Builing Debug...")
+    message("Building Debug...")
 
     add_definitions(-DDEBUG)
 endif ()


### PR DESCRIPTION
Seems to be of little use