### PR TITLE
rish: pass the stderr fd to start(), not stdout again

### DIFF
--- a/rish/src/main/java/rikka/rish/RishTerminal.java
+++ b/rish/src/main/java/rikka/rish/RishTerminal.java
@@ -87,7 +87,7 @@ public class RishTerminal {
     public void start() {
         Log.d(TAG, "start");
 
-        ttyFd = start(tty, getFd(stdin, 1), getFd(stdout, 0), getFd(stdout, 0));
+        ttyFd = start(tty, getFd(stdin, 1), getFd(stdout, 0), getFd(stderr, 0));
 
         if (ttyFd != -1) {
             new Thread(() -> {


### PR DESCRIPTION
Fixes the stdout/stderr mix-up reported in #178, analysed in #461, and first
pinpointed in #56 back in 2023.

### The defect

`start()` is declared as

```java
private static native int start(byte tty, int stdin, int stdout, int stderr);
```

but was called as

```java
ttyFd = start(tty, getFd(stdin, 1), getFd(stdout, 0), getFd(stdout, 0));
```

so the stdout read end is passed as both the stdout and the stderr fd. On the
native side both transfer threads then read the *same* pipe — one copying to
`STDOUT_FILENO`, the other to `STDERR_FILENO` — and race for each chunk, while
the `stderr` pipe created a few lines above is never read at all.

### Effect, and why it is easy to miss

With a tty, `ATTY_ERR` is set, no stderr pipe is made, and everything is
correct — so interactive use looks fine. It is only when output is redirected
or captured that the two threads exist, and then, measured on Shizuku
13.6.0.r1086:

- a command's stderr never arrives on either local stream (20/20 runs);
- its stdout arrives on local stdout or local stderr depending on which thread
  wins — exactly one of the two, never both (3/10 to 20/30 across sessions);
- larger payloads are split between the threads and, merged back with `2>&1`,
  arrive complete but out of order — 0/10 corrupt up to 64 KB while idle,
  6/10 at 128 KB and 256 KB, and worse under load. The length is always right
  and only the contents are wrong, so nothing warns the caller.

### The change

One argument: `getFd(stdout, 0)` → `getFd(stderr, 0)`.

`getFd()` already returns `-1` for a null array, so the tty case — where
`stderr` is left null and the native side skips it under `if (!err_tty)` — is
unaffected.

I confirmed the defect is present in the shipped artifact and not only in
source: disassembling `classes.dex` from the released APK, `RishTerminal.d()`
loads field `d` (stdout) twice and never reads field `e` (stderr) before
invoking `start(BIII)I`.

I have not been able to build and run a patched Shizuku to verify the fix end
to end — my only Android device is the one in the report, and reinstalling
Shizuku there would cost me the authorization I need to keep using it. So this
is verified by reading the shipped bytecode, not by execution, and deserves a
maintainer's eye on that basis.

---

*Investigated and drafted by Claude Opus 5, under my direction.*
